### PR TITLE
vge/materials/phong: fix build on Linux

### DIFF
--- a/vge/materials/phong/shaders.go
+++ b/vge/materials/phong/shaders.go
@@ -5,11 +5,11 @@ package phong
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V phong.vert.glsl -o phong.vert.spv
-//go:generate glslangValidator.exe -V phong.frag.glsl -o phong.frag.spv
+//go:generate glslangValidator -V phong.vert.glsl -o phong.vert.spv
+//go:generate glslangValidator -V phong.frag.glsl -o phong.frag.spv
 
-//go:embed phong.vert.gls
+//go:embed phong.vert.spv
 var phong_vert_spv []byte
 
-//go:embed phong.frag.gls
+//go:embed phong.frag.spv
 var phong_frag_spv []byte


### PR DESCRIPTION
This commit fixes the build on Linux.

Firstly, it removes the `.exe` extension from the glslangValidator
tool. Hopefully, this should still work on Windows. @lakal3 would
you be able to verify? I don't have access to a Windows machine.

It also updates the name of the SPIR-V files used by Go embed.
I reckon the `.gls` extension was an artifact from an earlier
version of VGE?