### PR TITLE
vgelib: fix build

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif()
-set(VULKAN_SDK "D:/Libs/VulkanSDK/1_1_101" CACHE PATH "Vulkan SDK path")
+set(VULKAN_SDK "" CACHE PATH "Vulkan SDK path")
 
 
 
@@ -21,7 +21,11 @@ set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 add_subdirectory("third_party/glfw")
 
-include_directories(${PROJECT_SOURCE_DIR} "third_party/glfw/include" "${VULKAN_SDK}/include" )
+include_directories(${PROJECT_SOURCE_DIR} "third_party/glfw/include")
+
+if(NOT VULKAN_SDK STREQUAL "")
+    include_directories("${VULKAN_SDK}/include")
+endif()
 
 if(NOT CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX d)
@@ -34,7 +38,11 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(VULKAN_LIB "${VULKAN_SDK}/lib/vulkan-1.lib")
     set(VGELIB_OS_SRC "vgelib/common/stb_image.cpp")
 else()
-    set(VULKAN_LIB "${VULKAN_SDK}/lib/libvulkan.so")
+    if(NOT VULKAN_SDK STREQUAL "")
+        set(VULKAN_LIB "${VULKAN_SDK}/lib/libvulkan.so")
+    else()
+        set(VULKAN_LIB "/usr/lib/libvulkan.so")
+    endif()
     set(VGELIB_OS_SRC "vgelib/common/stb_image.cpp" )
 endif()
 

--- a/cpp/vgelib/pipeline.cpp
+++ b/cpp/vgelib/pipeline.cpp
@@ -71,7 +71,7 @@ void vge::GraphicsPipeline::Create(RenderPass* renderPass)
 	pmsci.minSampleShading = 1;
 	pmsci.rasterizationSamples = vk::SampleCountFlagBits::e1;
 	gpci.pMultisampleState = &pmsci;
-	_pipeline = _dev->get_device().createGraphicsPipeline(nullptr, gpci, allocator, _dev->get_dispatch());
+	_pipeline = _dev->get_device().createGraphicsPipeline(nullptr, gpci, allocator, _dev->get_dispatch()).value;
 }
 
 void vge::GraphicsPipeline::AddVertexBinding(uint32_t stride, vk::VertexInputRate rate)
@@ -172,5 +172,5 @@ void vge::ComputePipeline::Create()
 		throw std::runtime_error("Compute shader need 1 stage");
 	}
 	cpci.stage = _shaders[0];
-	_pipeline = _dev->get_device().createComputePipeline(nullptr, cpci, allocator, _dev->get_dispatch());
+	_pipeline = _dev->get_device().createComputePipeline(nullptr, cpci, allocator, _dev->get_dispatch()).value;
 }


### PR DESCRIPTION
Explicitly access the value as member of ResultValue for
vk::Pipeline.

Fixes #2.

Upstream issue KhronosGroup/Vulkan-Hpp#616.

Also, from commit 3ec47289f14e8285234903178785b7fa33bd0cce.

 cpp: make Vulkan SDK path optional (default set to empty string)

On Arch Linux, the Vulkan SDK are split into dedicated packages
as recommended by LunarXchange [1].

Specifically, the two packages vulkan-headers and vulkan-icd-loader
contain the Vulkan headers and share libraries, respectively.

	$ pacman -Ql vulkan-headers
	vulkan-headers /usr/include/vulkan/vulkan.h
	vulkan-headers /usr/include/vulkan/vulkan.hpp

	$ pacman -Ql vulkan-icd-loader
	vulkan-icd-loader /usr/lib/libvulkan.so

As noted above, neither the Vulkan headers nor the shared library are
stored in a file path with a Vulkan SDK prefix directory. As such, the
CMake file prior to this commit did not support building VGE on
Arch Linux.

With this commit, building on Windows using CMake would require
setting VULKAN_SDK. As the previous setting required the SDK to be
placed on D:, which may not be the case for all Windows machines
this should make compilation on Windows more explicit.

From [1]: https://vulkan.lunarg.com/sdk/home#linux

> For other distributions of Linux, we recommend that you search your distribution's package repository for vulkan development libraries. Otherwise you may download and build from publicly available repositories.
>
> Loader: https://github.com/KhronosGroup/Vulkan-Loader
> Validation Layers: https://github.com/KhronosGroup/Vulkan-ValidationLayers
> GFXReconstruct: https://github.com/LunarG/gfxreconstruct
> Tools source: https://github.com/LunarG/VulkanTools
> Samples source: https://github.com/LunarG/VulkanSamples