### PR TITLE
examples: add examples build tag to exclude examples from default build

### DIFF
--- a/examples/basic/hello.go
+++ b/examples/basic/hello.go
@@ -1,3 +1,5 @@
+//+build examples
+
 package main
 
 import (

--- a/examples/basic/logo.go
+++ b/examples/basic/logo.go
@@ -1,3 +1,5 @@
+//+build examples
+
 package main
 
 import (

--- a/examples/basic/logo_an.go
+++ b/examples/basic/logo_an.go
@@ -1,3 +1,5 @@
+//+build examples
+
 package main
 
 import (


### PR DESCRIPTION
Fixes #4.

Note, this would have to be updated in Go 1.17 as the new Go build tag proposal has been accepted (https://github.com/golang/go/issues/41184).