### PR TITLE
vge/dyndl: fix Go build tag comment (reported by go vet)

### DIFF
--- a/vge/dldyn/dl.go
+++ b/vge/dldyn/dl.go
@@ -1,4 +1,5 @@
-// +build linux
+//+build linux
+
 package dldyn
 
 /*


### PR DESCRIPTION
Go build tag comments need to occur before the package clause
and have at least one new line between the comment and the
package clause.

Warning from go vet:
	dldyn/dl.go:1:1: +build comment must appear before package clause and be followed by a blank line