### PR TITLE
vge: drop `.exe` extension from glslangValidator to make go:generate …

### DIFF
--- a/vge/materials/debugmat/debugmat.go
+++ b/vge/materials/debugmat/debugmat.go
@@ -1,8 +1,8 @@
 //
 
-//go:generate glslangValidator.exe -V debugmat.vert.glsl -o debugmat.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 debugmat.vert.glsl -o debugmat.vert_skinned.spv
-//go:generate glslangValidator.exe -V debugmat.frag.glsl -o debugmat.frag.spv
+//go:generate glslangValidator -V debugmat.vert.glsl -o debugmat.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 debugmat.vert.glsl -o debugmat.vert_skinned.spv
+//go:generate glslangValidator -V debugmat.frag.glsl -o debugmat.frag.spv
 
 package debugmat
 

--- a/vge/materials/emissive/shaders.go
+++ b/vge/materials/emissive/shaders.go
@@ -4,9 +4,9 @@ package emissive
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V emissive.vert.glsl -o emissive.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 emissive.vert.glsl -o emissive.vert_skin.spv
-//go:generate glslangValidator.exe -V emissive.frag.glsl -o emissive.frag.spv
+//go:generate glslangValidator -V emissive.vert.glsl -o emissive.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 emissive.vert.glsl -o emissive.vert_skin.spv
+//go:generate glslangValidator -V emissive.frag.glsl -o emissive.frag.spv
 
 //go:embed emissive.frag.spv
 var emissive_frag_spv []byte

--- a/vge/materials/env/shaders.go
+++ b/vge/materials/env/shaders.go
@@ -4,11 +4,11 @@ package env
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V eqrect.vert.glsl -o eqrect.vert.spv
-//go:generate glslangValidator.exe -V eqrect.frag.glsl -o eqrect.frag.spv
-//go:generate glslangValidator.exe -V graybg.frag.glsl -o graybg.frag.spv
-//go:generate glslangValidator.exe -V probe.comp.glsl -o probe.comp.spv
-//go:generate glslangValidator.exe -V sph.comp.glsl -o sph.comp.spv
+//go:generate glslangValidator -V eqrect.vert.glsl -o eqrect.vert.spv
+//go:generate glslangValidator -V eqrect.frag.glsl -o eqrect.frag.spv
+//go:generate glslangValidator -V graybg.frag.glsl -o graybg.frag.spv
+//go:generate glslangValidator -V probe.comp.glsl -o probe.comp.spv
+//go:generate glslangValidator -V sph.comp.glsl -o sph.comp.spv
 
 //go:embed eqrect.vert.spv
 var eqrect_vert_spv []byte

--- a/vge/materials/noise/shaders.go
+++ b/vge/materials/noise/shaders.go
@@ -4,8 +4,8 @@ package noise
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V fire.vert.glsl -o fire.vert.spv
-//go:generate glslangValidator.exe -V fire.frag.glsl -o fire.frag.spv
+//go:generate glslangValidator -V fire.vert.glsl -o fire.vert.spv
+//go:generate glslangValidator -V fire.frag.glsl -o fire.frag.spv
 
 //go:embed fire.frag.spv
 var fire_frag_spv []byte

--- a/vge/materials/pbr/shaders.go
+++ b/vge/materials/pbr/shaders.go
@@ -5,9 +5,9 @@ package pbr
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V pbr.vert.glsl -o pbr.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 pbr.vert.glsl -o pbr.vert_skin.spv
-//go:generate glslangValidator.exe -V pbr.frag.glsl -o pbr.frag.spv
+//go:generate glslangValidator -V pbr.vert.glsl -o pbr.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 pbr.vert.glsl -o pbr.vert_skin.spv
+//go:generate glslangValidator -V pbr.frag.glsl -o pbr.frag.spv
 
 //go:embed pbr.vert.spv
 var pbr_vert_spv []byte

--- a/vge/materials/predepth/shaders.go
+++ b/vge/materials/predepth/shaders.go
@@ -4,9 +4,9 @@ package predepth
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V predepth.vert.glsl -o predepth.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 predepth.vert.glsl -o predepth.vert_skin.spv
-//go:generate glslangValidator.exe -V predepth.frag.glsl -o predepth.frag.spv
+//go:generate glslangValidator -V predepth.vert.glsl -o predepth.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 predepth.vert.glsl -o predepth.vert_skin.spv
+//go:generate glslangValidator -V predepth.frag.glsl -o predepth.frag.spv
 
 //go:embed predepth.frag.spv
 var predepth_frag_spv []byte

--- a/vge/materials/shadow/shaders.go
+++ b/vge/materials/shadow/shaders.go
@@ -4,10 +4,10 @@ package shadow
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V shadow.vert.glsl -o shadow.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 shadow.vert.glsl -o shadow.vert_skin.spv
-//go:generate glslangValidator.exe -V shadow.geom.glsl -o shadow.geom.spv
-//go:generate glslangValidator.exe -V shadow.frag.glsl -o shadow.frag.spv
+//go:generate glslangValidator -V shadow.vert.glsl -o shadow.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 shadow.vert.glsl -o shadow.vert_skin.spv
+//go:generate glslangValidator -V shadow.geom.glsl -o shadow.geom.spv
+//go:generate glslangValidator -V shadow.frag.glsl -o shadow.frag.spv
 
 //go:embed shadow.frag.spv
 var shadow_frag_spv []byte

--- a/vge/materials/std/shaders.go
+++ b/vge/materials/std/shaders.go
@@ -4,9 +4,9 @@ package std
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V std.vert.glsl -o std.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 std.vert.glsl -o std.vert_skin.spv
-//go:generate glslangValidator.exe -V std.frag.glsl -o std.frag.spv
+//go:generate glslangValidator -V std.vert.glsl -o std.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 std.vert.glsl -o std.vert_skin.spv
+//go:generate glslangValidator -V std.frag.glsl -o std.frag.spv
 
 //go:embed std.frag.spv
 var std_frag_spv []byte

--- a/vge/materials/unlit/shaders.go
+++ b/vge/materials/unlit/shaders.go
@@ -4,9 +4,9 @@ package unlit
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V unlit.vert.glsl -o unlit.vert.spv
-//go:generate glslangValidator.exe -V -DSKINNED=1 unlit.vert.glsl -o unlit.vert_skin.spv
-//go:generate glslangValidator.exe -V unlit.frag.glsl -o unlit.frag.spv
+//go:generate glslangValidator -V unlit.vert.glsl -o unlit.vert.spv
+//go:generate glslangValidator -V -DSKINNED=1 unlit.vert.glsl -o unlit.vert_skin.spv
+//go:generate glslangValidator -V unlit.frag.glsl -o unlit.frag.spv
 
 //go:embed unlit.frag.spv
 var unlit_frag_spv []byte

--- a/vge/vglyph/shaders.go
+++ b/vge/vglyph/shaders.go
@@ -4,11 +4,11 @@ package vglyph
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V copy.comp.glsl -o copy.comp.spv
-//go:generate glslangValidator.exe -V copy_rgb.comp.glsl -o copy_rgb.comp.spv
-//go:generate glslangValidator.exe -V vdepth.comp.glsl -o vdepth.comp.spv
-//go:generate glslangValidator.exe -V glyph.vert.glsl -o glyph.vert.spv
-//go:generate glslangValidator.exe -V glyph.frag.glsl -o glyph.frag.spv
+//go:generate glslangValidator -V copy.comp.glsl -o copy.comp.spv
+//go:generate glslangValidator -V copy_rgb.comp.glsl -o copy_rgb.comp.spv
+//go:generate glslangValidator -V vdepth.comp.glsl -o vdepth.comp.spv
+//go:generate glslangValidator -V glyph.vert.glsl -o glyph.vert.spv
+//go:generate glslangValidator -V glyph.frag.glsl -o glyph.frag.spv
 
 //go:embed copy.comp.spv
 var copy_comp_spv []byte

--- a/vge/vk/renderpass_test.go
+++ b/vge/vk/renderpass_test.go
@@ -1,7 +1,7 @@
 //
 
-//go:generate glslangValidator.exe -V testsh/testsh.vert.glsl -o testsh/testsh.vert.spv
-//go:generate glslangValidator.exe -V testsh/testsh.frag.glsl -o testsh/testsh.frag.spv
+//go:generate glslangValidator -V testsh/testsh.vert.glsl -o testsh/testsh.vert.spv
+//go:generate glslangValidator -V testsh/testsh.frag.glsl -o testsh/testsh.frag.spv
 
 package vk
 

--- a/vge/vmodel/shaders.go
+++ b/vge/vmodel/shaders.go
@@ -4,7 +4,7 @@ package vmodel
 
 import _ "embed"
 
-//go:generate glslangValidator.exe -V genmip.comp.glsl -o genmip.comp.spv
+//go:generate glslangValidator -V genmip.comp.glsl -o genmip.comp.spv
 
 //go:embed genmip.comp.spv
 var genmip_comp_spv []byte


### PR DESCRIPTION
…rule work cross-platform

Follow-up commit to PR #1.