### PR TITLE
all: use lower case file name for vgelib.dll and libvgelib.so

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(VGELib C CXX)
+project(vgelib C CXX)
 
 if(NOT CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX d)
@@ -46,7 +46,7 @@ else()
     set(VGELIB_OS_SRC "vgelib/common/stb_image.cpp" )
 endif()
 
-add_library(VGELib SHARED ${VGELIB_SRC} ${VGELIB_SRCH} ${VGELIB_OS_SRC})
-target_link_libraries(VGELib ${VULKAN_LIB} glfw)
+add_library(vgelib SHARED ${VGELIB_SRC} ${VGELIB_SRCH} ${VGELIB_OS_SRC})
+target_link_libraries(vgelib ${VULKAN_LIB} glfw)
 
-install(TARGETS VGELib DESTINATION "bin")
+install(TARGETS vgelib DESTINATION "bin")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,14 +37,14 @@ If we consider languages that have a reasonable user base, this only leaves few 
 
 In reality all operating system APIs, the Vulkan API, and most graphics libraries, algorithms etc. have been written in C/C++. All API:s use C ABI conventions. In some way, you must be able to consume .h(.hpp) files or write lots and lots of things from scratch.
 
-So the lowest level of the VGE is a shader library VGELib written in C++. It incorporates some really fine libraries that makes the graphics engine design easier.
+So the lowest level of the VGE is a shader library vgelib written in C++. It incorporates some really fine libraries that makes the graphics engine design easier.
 VGE only uses C/C++ libraries if no equivalent pure Go library is available (with exception of reading JPEG images. The Go standard implementation was incredibly slow).
 
-If you want to manually build the C++ library see [building VGELib](build_vgelib.md).
+If you want to manually build the C++ library see [building vgelib](build_vgelib.md).
 
 ### C++ but, no CGO (or very little in Linux)
 
-To make using VGE easier, no C++ compiler is required when running VGE on Windows. VGE only uses syscall to load VGELib shared library.
+To make using VGE easier, no C++ compiler is required when running VGE on Windows. VGE only uses syscall to load vgelib shared library.
 This also means that VGE in Windows is not an CGO program.
 
 Unfortunately, in Linux there is no way (that I am aware of) to load a shared library
@@ -56,9 +56,9 @@ You do not to know anything about this tool unless you plan to change the Go/C++
 
 ### GODEBUG=cgocheck=0
 
-For performance reason VGE will pass pointers to Go memory. VGE support library VGELib.dll (libVGELib.so) is aware of Golangs carbage collector and will not hold pointer to memory after call to library completed. As long as Golang don't implement moving carbage collector this is safe! 
+For performance reason VGE will pass pointers to Go memory. VGE support library vgelib.dll (libvgelib.so) is aware of Golangs carbage collector and will not hold pointer to memory after call to library completed. As long as Golang don't implement moving carbage collector this is safe!
 
-In Windows this works out of box. However in Linux we must use short CGO module to invoke libVGELib.so. 
+In Windows this works out of box. However in Linux we must use short CGO module to invoke libvgelib.so.
 Unfortunately current implementation of CGO will check that we will not send pointers from Go's heap to CGO calls :(. cgocheck=0 will disable this check.
 
 **Go 1.17 will most like support new Handle type that solves this problem!**

--- a/docs/build_vgelib.md
+++ b/docs/build_vgelib.md
@@ -1,8 +1,8 @@
-# Build VGELib.dll (libVGELib.so)
+# Build vgelib.dll (libvgelib.so)
 
 ## Depencendicies
 
-VGELib uses [GLFW](https://www.glfw.org/) library to handle native UI / event handling in a platform independent manner.
+vgelib uses [GLFW](https://www.glfw.org/) library to handle native UI / event handling in a platform independent manner.
 GLFW is included in the VGE project as a git submodule.
 
 You must update submodules to download the actual GLTW code using the git submodule command.
@@ -17,7 +17,7 @@ Other dependencies (std_image.h) are included in the VGE project.
 
 Download and install [Vulkan SDK](https://vulkan.lunarg.com/). 
 
-Default VGELib.dll has been built with SDK version 1.2.170. 
+Default vgelib.dll has been built with SDK version 1.2.170.
 
 Optionally: Run vkcube example from SDK to check that your display drivers support Vulkan.
 
@@ -27,13 +27,13 @@ VGE is fairly standard C++ code and does not use advanced C++ concepts. However,
 
 ## CMake
 
-VGELib uses CMake build system.
+vgelib uses CMake build system.
 In addition to the normal CMake parameters you must define the VULKAN_SDK cache variable
 that must point to the directory where you installed Vulkan SDK
 
 `cmake -DVULKAN_SDK={Vulkan SDK install path} ...`
 
-Installing release mode binaries should install a new version of VGELib.dll (libVGELib.so)
+Installing release mode binaries should install a new version of vgelib.dll (libvgelib.so)
 
 ## Linux build
 
@@ -50,7 +50,7 @@ Linux needs additional libraries to build GLWF. You should have at least install
 
 See their documentation about the requirements (or just run make and install what is missing).
 
-Also, make sure that you place your shared library (libVGELib.so) where the OS will be able to locate it.
+Also, make sure that you place your shared library (libvgelib.so) where the OS will be able to locate it.
 
 ## Windows build
 

--- a/docs/linux_install.md
+++ b/docs/linux_install.md
@@ -12,10 +12,10 @@ Getting a working Vulkan driver on Linux machine seems bit more involved process
 
 This step is optional but recommended.
 
-## libVGELib.so
+## libvgelib.so
 
-Place prebuilt libVGELib.so so that Linux loader can find it.
-Alternatively [build](build_vgelib.md) libVGELib.so yourself.
+Place prebuilt libvgeLib.so so that Linux loader can find it.
+Alternatively [build](build_vgelib.md) libvgelib.so yourself.
 
 Please follow your distribution specific instructions on how to install shared libraries.
 

--- a/docs/vimage.md
+++ b/docs/vimage.md
@@ -31,7 +31,7 @@ PNG images have two loaders available: PngLoader and NativeLoader.
 PngLoader is using Go's image and png packages. Register this loader using pngloader.RegisterPngLoader.
 Go's implementation of PNG loader can both read and write png images, but reading might be a bit slower than when using NativeLoader.
 
-NativeLoader is implemented in C++ VGELib and uses internally stb_image.h image loaders.
+NativeLoader is implemented in C++ vgelib and uses internally stb_image.h image loaders.
 NativeLoader is registered with vasset.RegisterNativeImageLoader. NativeLoader can only read PNG images.
 
 You can use PngLoader to write images and NativeLoader to load images if you register PngLoader before.

--- a/docs/vk.md
+++ b/docs/vk.md
@@ -1,7 +1,7 @@
 # VGE core object (Module vk)
 
 This module contains the lower levels of VGE objects written in Go.
-The Vk module is also the only module that directly calls C++ library VGELib.dll (libVGELib.so)
+The Vk module is also the only module that directly calls C++ library vgelib.dll (libvgelib.so)
 
 Main objects in code module:
 

--- a/examples/animate/main.go
+++ b/examples/animate/main.go
@@ -48,8 +48,8 @@ func main() {
 	}
 	if app.debug {
 		vapp.AddOption(vapp.Validate{})
-		// Uncommment next line to run with debug version on VGELib. NOTE! Debug versions are not included in prebuilt. You must build one yourself
-		// vk.VGEDllPath = "VGELibd.dll"
+		// Uncommment next line to run with debug version on vgelib. NOTE! Debug versions are not included in prebuilt. You must build one yourself
+		// vk.VGEDllPath = "vgelibd.dll"
 	}
 	vasset.DefaultLoader = vasset.DirectoryLoader{Directory: "../../assets"}
 

--- a/examples/basic/basic_samples.md
+++ b/examples/basic/basic_samples.md
@@ -7,8 +7,8 @@ These examples will use the vapp package to setup, for example, the Vulkan appli
 have to take care of the many details you would normally have to setup when creating a Vulkan application.
 
 To run the examples, just use go run. Ensure that you have either:
-- Built and installed VGELib.dll (.so) package
-- Copied this dll from {rootdir}/prebuild/{win/linux}/VGELib.dll
+- Built and installed vgelib.dll (.so) package
+- Copied this dll from {rootdir}/prebuild/{win/linux}/vgelib.dll
 
 ## Examples in this directory
 
@@ -18,7 +18,7 @@ To run the examples, just use go run. Ensure that you have either:
 
 ## Troubleshooting
 
-Check that VGELib.dll (.so) is accessible using the path.
+Check that vgelib.dll (.so) is accessible using the path.
 
 Check that GOARCH is amd64. This is the only supported architecture.
 

--- a/examples/cube/main.go
+++ b/examples/cube/main.go
@@ -58,7 +58,7 @@ func main() {
 	flag.Parse()
 
 	if config.debug {
-		// vk.VGEDllPath = "VGELibd.dll"
+		// vk.VGEDllPath = "vgelibd.dll"
 	}
 	app.init()
 	defer app.Dispose()

--- a/examples/gltfviewer/main.go
+++ b/examples/gltfviewer/main.go
@@ -59,7 +59,7 @@ func main() {
 	if app.debug {
 		vapp.AddOption(vapp.Validate{})
 		// Uncomment to use C++ debug library
-		// vk.VGEDllPath = "VGELibd.dll"
+		// vk.VGEDllPath = "vgelibd.dll"
 	}
 	if app.deferred {
 		// Deferred shaders requires dynamic descriptors

--- a/examples/robomaze/main.go
+++ b/examples/robomaze/main.go
@@ -62,7 +62,7 @@ func main() {
 	}
 	if debug {
 		vapp.AddOption(vapp.Validate{})
-		// vk.VGEDllPath = "VGELibd.dll"
+		// vk.VGEDllPath = "vgelibd.dll"
 	}
 	if app.oil || app.deferred {
 		// Add dynamics descriptor support.

--- a/examples/ui/main.go
+++ b/examples/ui/main.go
@@ -65,7 +65,7 @@ func main() {
 	flag.Parse()
 	if config.debug {
 		// Comment out if you wan't to test app with debug library
-		//vk.VGEDllPath = "VGELibd.dll"
+		//vk.VGEDllPath = "vgelibd.dll"
 	}
 	app.init()
 	defer app.Dispose()

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Running logo.go with `go run logo.go` should produce something like.
 
 ![alt text](docs/logo_example.png "Logo example")
 
-In Linux use `GODEBUG=cgocheck=0 go run logo.go` (*VGE will pass raw pointer to its support library libVGELib.so for performance reasons. See [Architecture](docs/achiteture.md) for more info*)
+In Linux use `GODEBUG=cgocheck=0 go run logo.go` (*VGE will pass raw pointer to its support library libvgelib.so for performance reasons. See [Architecture](docs/achiteture.md) for more info*)
 
 ## Sample videos
 
@@ -142,10 +142,10 @@ Note **Only 64bit (amd64) Windows (only tested on Windows 10) or Linux (experime
 
 Some lower level functions are implemented in C++. See [VGE architecture](docs/architecture.md) for more description of why and how VGE is implemented.
 
-On Windows, you do not have to install the C/C++ compiler. You can use a prebuilt C++ VGELib.dll. Windows implementation does not use the CGO at all!
+On Windows, you do not have to install the C/C++ compiler. You can use a prebuilt C++ vgelib.dll. Windows implementation does not use the CGO at all!
 
-Copy prebuilt/win_amd64/VGELib.dll to some directory in your search PATH or update searchpath to include prebuilt directory.
-Alternatively you can [build VGELib](docs/build_vgelib.md) VGELib.dll yourself.
+Copy prebuilt/win_amd64/vgelib.dll to some directory in your search PATH or update searchpath to include prebuilt directory.
+Alternatively you can [build vgelib](docs/build_vgelib.md) vgelib.dll yourself.
 
 If you plan to do any additional projects with Vulkan or the VGE, I also recommend you to install [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/).
 Vulkan SDK also contains the SPIR-V compiler that you will need when developing your own shaders.

--- a/tests/mattest/main.go
+++ b/tests/mattest/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 	if app.debug {
 		vapp.AddOption(vapp.Validate{})
-		// vk.VGEDllPath = "VGELibd.dll"
+		// vk.VGEDllPath = "vgelibd.dll"
 	}
 
 	var err error

--- a/vge/dldyn/dl.go
+++ b/vge/dldyn/dl.go
@@ -56,7 +56,7 @@ import (
 
 type Handle uintptr
 
-// DLOpen opens libVGElib.so.
+// DLOpen opens libvgelib.so.
 func DLOpen(libraryPath string) (Handle, error) {
 	if strings.HasSuffix(strings.ToLower(libraryPath), ".dll") {
 		// Convert Windows dll name to Linux equivalent
@@ -79,7 +79,7 @@ func GetProcAddress(libHandle Handle, exportName string) (trap uintptr, err erro
 	return uintptr(mh), nil
 }
 
-// DLClose closes libVGElib.so
+// DLClose closes libvgelib.so
 func DLClose(libHandle Handle) {
 	// FreeLibrary releases previously loaded library
 	C.dlclose(unsafe.Pointer(libHandle))

--- a/vge/vasset/imageloader.go
+++ b/vge/vasset/imageloader.go
@@ -67,7 +67,7 @@ func RegisterImageLoader(loader vk.ImageLoader) {
 	imageLoaders = append([]vk.ImageLoader{loader}, imageLoaders...)
 }
 
-// RegisterNativeImageLoader register loader implemented in VGELib (using stb_image.h image loaders)
+// RegisterNativeImageLoader register loader implemented in vgelib (using stb_image.h image loaders)
 func RegisterNativeImageLoader(ctx vk.APIContext, app *vk.Application) {
 	ld := vk.NewNativeImageLoader(ctx, app)
 	if ld != nil {

--- a/vge/vk/application.go
+++ b/vge/vk/application.go
@@ -39,14 +39,14 @@ func DebugPoint(point string) {
 	call_DebugPoint([]byte(point))
 }
 
-// VGEDllPath sets name of default VGELib path.
-var VGEDllPath string = "VGELib.dll"
+// VGEDllPath sets name of default vgelib path.
+var VGEDllPath string = "vgelib.dll"
 
-// GetDllPath gets full path of VGELib.dll (.so). You can override this function to match your preferences / OS.
-// By default in Windows file name is kept as is. In linux -> VGELib will be converted to libVGElib and .dll -> .so
+// GetDllPath gets full path of vgelib.dll (.so). You can override this function to match your preferences / OS.
+// By default in Windows file name is kept as is. In linux -> vgelib will be converted to libvgelib and .dll -> .so
 var GetDllPath = func() string {
 	if runtime.GOOS == "linux" {
-		p := strings.ReplaceAll(VGEDllPath, "VGELib", "libVGELib")
+		p := strings.ReplaceAll(VGEDllPath, "vgelib", "libvgelib")
 		return strings.ReplaceAll(p, ".dll", ".so")
 	}
 	return VGEDllPath

--- a/vge/vk/application_test.go
+++ b/vge/vk/application_test.go
@@ -38,7 +38,7 @@ func TestAddDynamicDescriptors(t *testing.T) {
 }
 
 func TestNewApplication(t *testing.T) {
-	// VGEDllPath = "VGELibd.dll"
+	// VGEDllPath = "vgelibd.dll"
 	tc := &testContext{t: t}
 	a := NewApplication(tc, "Test")
 	a.AddValidation(tc)

--- a/vge/vk/desktop.go
+++ b/vge/vk/desktop.go
@@ -24,7 +24,7 @@ type DesktopSettings struct {
 }
 
 // NewDesktopWithSettings will initialize application with swap chain. You can set requested flags for image usage for main image when
-// VGElib constructs new swapchain for Windows. Default settings are IMAGEUsageColorAttachmentBit | IMAGEUsageTransferSrcBit
+// vgelib constructs new swapchain for Windows. Default settings are IMAGEUsageColorAttachmentBit | IMAGEUsageTransferSrcBit
 func NewDesktopWithSettings(ctx APIContext, app *Application, settings DesktopSettings) *Desktop {
 	if app.hInst != 0 {
 		ctx.SetError(ErrInitialized)


### PR DESCRIPTION
This change is made for two primary reasons, the first being
to make life easier on Linux (and Unix) systems which have
case sensitive file systems.

Prior to this change, there was a mix of casing used for the libvge
shared libraries (e.g. only lower case, mix between upper and lower
case). After this change, all uses are consistent and always lower
case.